### PR TITLE
add typings to waitPort

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+interface ServerLocation {
+  port: number;
+  host?: string;
+}
+
+const waitPort: (server: ServerLocation, timeout?: number) => Promise<boolean>;
+
+export default waitPort;


### PR DESCRIPTION
AFAIK "host" is optional and port is required. The timeout is also optional, and the promise resolves with a boolean.