### PR TITLE
Type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ interface ServerLocation {
   /** If using the 'http' protocol, the path to check
    * (defaults to '/' if protocol is 'http') */
   path?: string;
-  
+
   /** The number of milliseconds to wait on each connection attempt
    * (defaults to 1000) */
   interval?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,26 +2,34 @@ interface ServerLocation {
   /** The port to wait for */
   port: number;
 
-  /** The host to check, if not localhost */
+  /** The host to check
+   * (defaults to 'localhost') */
   host?: string;
 
   /** Set to 'http' to test an HTTP request as well */
   protocol?: 'http';
 
-  /** If using the 'http' protocol, the path to check */
+  /** If using the 'http' protocol, the path to check
+   * (defaults to '/' if protocol is 'http') */
   path?: string;
-
+  
   /** The number of milliseconds to wait on each connection attempt
+   * (defaults to 1000) */
+  interval?: number;
+
+  /** The number of milliseconds to wait before giving up
    * (defaults to 0) */
   timeout?: number;
 
-  /** Whether to wait for DNS to resolve, defaults to false */
+  /** Whether to wait for DNS to resolve
+   * (defaults to false) */
   waitForDns?: boolean;
 
-  /** Output mode */
+  /** Output mode
+   * (defaults to 'dots') */
   output?: 'dots' | 'silent';
 }
 
-declare const waitPort: (server: ServerLocation, timeout?: number) => Promise<boolean>;
+declare const waitPort: (server: ServerLocation) => Promise<boolean>;
 
 export default waitPort;


### PR DESCRIPTION
I realized that I get typescript compiler errors if I use the `interval` option.

So I updated the type definitions to align with the implementation.