### PR TITLE
Use proper typing for waitPort

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,4 +32,4 @@ interface ServerLocation {
 
 declare const waitPort: (server: ServerLocation) => Promise<boolean>;
 
-export default waitPort;
+export = waitPort;


### PR DESCRIPTION
Based on the code I see, I don't believe that you are exporting a waitPort.default function.

When you create the default syntax in typescript, it would normally compile the file as:

```JavaScript
module.exports.default = waitPort;
```

And you would import it from typescript the following ways. 

```TypeScript
import waitPort from 'wait-port';
// or
import { default } from 'wait-port';
```

Both of those imports access the same object.

Without this fix, I have come up with a temp fix for using this.

```TypeScript
import * as waitPort from 'wait-port';

// The as any is required to make the TypeScript compiler happy
await (waitPort as any)({
    port: 3000
});
```

By using `export = waitFor`, you are telling TypeScript that the module.export is the function. So in my above example I could have type safety.

```TypeScript
import * as waitPort from 'wait-port';

// No longer need to use any.
await waitPort({
    port: 3000
});
```