### PR TITLE
http request: send valid HTTP Request

### DIFF
--- a/lib/wait-port.js
+++ b/lib/wait-port.js
@@ -37,11 +37,7 @@ function createConnectionWithTimeout({ host, port }, timeout, callback) {
 
 function checkHttp(socket, params, timeout, callback) {
   //  Create the HTTP request.
-  const request = 
-`GET ${params.path} HTTP/1.1
-Host: ${params.host}
-
-`;
+  const request = `GET ${params.path} HTTP/1.1\r\nHost: ${params.host}\r\n\r\n`;
 
   let timer = null;
   timer = setTimeout(() => {


### PR DESCRIPTION
We use `wait-port` over in [`netlify-cli`](https://github.com/netlify/cli).

Our tests started erroring out recently, and I realized that `wait-port` isn't necessarily sending `\r\n` (carriage return + line feed -- see https://datatracker.ietf.org/doc/html/rfc7230#section-3)