### PR TITLE
feat: Allow specifiying IP family for name resolution

### DIFF
--- a/bin/wait-port.js
+++ b/bin/wait-port.js
@@ -14,6 +14,7 @@ program
   .description('Wait for a target to accept connections, e.g: wait-port localhost:8080')
   .option('-t, --timeout [n]', 'Timeout', parseInt)
   .option('-o, --output [mode]', 'Output mode (silent, dots). Default is silent.')
+  .option('-f, --family [family]', 'IP family (0, 4, 6). Default is 0.', parseInt)
   .option('--wait-for-dns', 'Do not fail on ENOTFOUND, meaning you can wait for DNS record creation. Default is false.')
   .arguments('<target>')
   .action(async (target) => {
@@ -21,17 +22,20 @@ program
       const { protocol, host, port, path } = extractTarget(target);
       const timeout = program.timeout || 0;
       const output = program.output;
+      const family = program.family || 0;
       const waitForDns = program.waitForDns;
 
       debug(`Timeout: ${timeout}`);
       debug(`Target: ${target} => ${protocol}://${host}:${port}${path}`);
       debug(`waitForDns: ${waitForDns}`);
+      debug(`Family: ${family}`);
 
       const params = {
         timeout,
         protocol,
         host,
         port,
+        family,
         path,
         output,
         waitForDns,

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,9 @@ interface ServerLocation {
    * (defaults to 'localhost') */
   host?: string;
 
+  /** Set the IP family for the name resolution */
+  family?: 0 | 4 | 6;
+
   /** Set to 'http' to test an HTTP request as well */
   protocol?: 'http';
 

--- a/lib/validate-parameters.js
+++ b/lib/validate-parameters.js
@@ -18,6 +18,11 @@ function validateParameters(params) {
   //  Coerce the host.
   const host = params.host || 'localhost';
 
+  //  Coerce the family.
+  const family = params.family || 0;
+  if (!Number.isInteger(family)) throw new ValidationError('\'family\' must be a number.');
+  if (family !== 0 && family !== 4 && family !== 6) throw new ValidationError('\'family\' must be 0, 4, or 6.');
+
   //  Coerce the path.
   //  If we have the http protocol, but no path, assume root.
   const path = params.path || (protocol === 'http' ? '/' : undefined);
@@ -51,6 +56,7 @@ function validateParameters(params) {
     protocol,
     port,
     host,
+    family,
     path,
     interval,
     timeout,

--- a/lib/validate-parameters.spec.js
+++ b/lib/validate-parameters.spec.js
@@ -6,6 +6,7 @@ describe('validateParameters', () => {
     return {
       host: 'localhost',
       port: 8080,
+      family: 4,
       interval: 2000,
       timeout: 0,
       output: 'silent',
@@ -49,7 +50,7 @@ describe('validateParameters', () => {
   });
 
   it('coerce an empty host into \'localhost\'', () => {
-	
+
     const params = validParams();
     delete params.host;
     const validatedParams = validateParameters(params);
@@ -57,11 +58,47 @@ describe('validateParameters', () => {
 
   });
 
+  it('coerce an empty family into 0', () => {
+
+    const params = validParams();
+    delete params.family;
+    const validatedParams = validateParameters(params);
+    assert.strictEqual(validatedParams.family, 0);
+
+  });
+
+  it('should throw if an invalid family is specified', () => {
+
+    const params = validParams();
+    params.family = 'string';
+    assert.throws(() => validateParameters(params), /family.*number/);
+    params.family = -1;
+    assert.throws(() => validateParameters(params), /family.*0, 4, or 6/);
+    params.family = 5;
+    assert.throws(() => validateParameters(params), /family.*0, 4, or 6/);
+
+  });
+
+  it('should allow valid family parameter', () => {
+
+    const params = validParams();
+    params.family = 0;
+    let validatedParams = validateParameters(params);
+    assert.strictEqual(validatedParams.family, 0);
+    params.family = 4;
+    validatedParams = validateParameters(params);
+    assert.strictEqual(validatedParams.family, 4);
+    params.family = 6;
+    validatedParams = validateParameters(params);
+    assert.strictEqual(validatedParams.family, 6);
+
+  });
+
   it('should allow an undefined path', () => {
 
     const params = validParams();
     assert.strictEqual(validateParameters(params).path, undefined);
-  
+
   });
 
   it('should set the path to root if the http protocol is used but no path is specified', () => {

--- a/lib/wait-port.js
+++ b/lib/wait-port.js
@@ -4,13 +4,13 @@ const outputFunctions = require('./output-functions');
 const validateParameters = require('./validate-parameters');
 const ConnectionError = require('./errors/connection-error');
 
-function createConnectionWithTimeout({ host, port }, timeout, callback) {
+function createConnectionWithTimeout({ host, port, family }, timeout, callback) {
   //  Variable to hold the timer we'll use to kill the socket if we don't
   //  connect in time.
   let timer = null;
 
   //  Try and open the socket, with the params and callback.
-  const socket = net.createConnection({ host, port }, (err) => {
+  const socket = net.createConnection({ host, port, family }, (err) => {
     if (!err) clearTimeout(timer);
     return callback(err);
   });
@@ -122,7 +122,7 @@ function tryConnect(options, timeout) {
           socket.destroy();
           return reject(err);
         }
-      
+
         //  Boom, we connected!
         debug('Socket connected!');
 
@@ -171,6 +171,7 @@ function waitPort(params) {
       protocol,
       host,
       port,
+      family,
       path,
       interval,
       timeout,
@@ -191,7 +192,7 @@ function waitPort(params) {
     //  Start trying to connect.
     const loop = () => {
       outputFunction.tryConnect();
-      tryConnect({ protocol, host, port, path, waitForDns }, connectTimeout)
+      tryConnect({ protocol, host, port, family, path, waitForDns }, connectTimeout)
         .then((open) => {
           debug(`Socket status is: ${open}`);
 


### PR DESCRIPTION
This allows specifying the IP family for the name resolution. https://nodejs.org/api/net.html#socketconnectoptions-connectlistener

This can solve #81, for example if you are using `waitPort({ port: 8888, host: 'localhost', family: 4 })` to force the name resolution to resolve `localhost` to `127.0.0.1` instead of `::1`. As Node.js changed the [default in version 17 ](https://github.com/nodejs/node/issues/40537) this allows solving the issue if one knows what IP family you are waiting for.

The default is 0 which means either IPv6 or IPv4 and the order depends on the system.

Our use case is that we wait for a local development server to start, which we know runs on IPv4.