### PR TITLE
fix: Check both IPv4 and IPv6 when dns-name supplied

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ const params = {
 };
 
 waitPort(params)
-  .then((open) => {
-    if (open) console.log('The port is now open!');
+  .then(({ open, ipVersion }) => {
+    if (open) console.log(`The port is now open on IPv${ipVersion}!`);
     else console.log('The port did not open before the timeout...');
   })
   .catch((err) => {

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,11 @@ interface ServerLocation {
   output?: 'dots' | 'silent';
 }
 
-declare const waitPort: (server: ServerLocation) => Promise<boolean>;
+interface ReturnObject {
+  open: boolean;
+  ipVersion?: 4 | 6;
+}
+
+declare const waitPort: (server: ServerLocation) => Promise<ReturnObject>;
 
 export = waitPort;

--- a/lib/wait-port.js
+++ b/lib/wait-port.js
@@ -4,13 +4,13 @@ const outputFunctions = require('./output-functions');
 const validateParameters = require('./validate-parameters');
 const ConnectionError = require('./errors/connection-error');
 
-function createConnectionWithTimeout({ host, port }, timeout, callback) {
+function createConnectionWithTimeout({ host, port, ipVersion }, timeout, callback) {
   //  Variable to hold the timer we'll use to kill the socket if we don't
   //  connect in time.
   let timer = null;
 
   //  Try and open the socket, with the params and callback.
-  const socket = net.createConnection({ host, port }, (err) => {
+  const socket = net.createConnection({ host, port, family: ipVersion }, (err) => {
     if (!err) clearTimeout(timer);
     return callback(err);
   });
@@ -26,7 +26,7 @@ function createConnectionWithTimeout({ host, port }, timeout, callback) {
   //  Kill the socket if we don't open in time.
   timer = setTimeout(() => {
     socket.destroy();
-    const error = new Error(`Timeout trying to open socket to ${host}:${port}`);
+    const error = new Error(`Timeout trying to open socket to ${host}:${port}, IPv${ipVersion}`);
     error.code = 'ECONNTIMEOUT';
     callback(error);
   }, timeout);
@@ -42,7 +42,7 @@ function checkHttp(socket, params, timeout, callback) {
   let timer = null;
   timer = setTimeout(() => {
     socket.destroy();
-    const error = new Error(`Timeout waiting for data from ${params.host}:${params.port}`);
+    const error = new Error(`Timeout waiting for data from ${params.host}:${params.port}, IPv${params.ipVersion}`);
     error.code = 'EREQTIMEOUT';
     callback(error);
   }, timeout);
@@ -122,7 +122,7 @@ function tryConnect(options, timeout) {
           socket.destroy();
           return reject(err);
         }
-      
+
         //  Boom, we connected!
         debug('Socket connected!');
 
@@ -189,22 +189,27 @@ function waitPort(params) {
     outputFunction.starting({ host, port });
 
     //  Start trying to connect.
-    const loop = () => {
+    const loop = (ipVersion = 4) => {
       outputFunction.tryConnect();
-      tryConnect({ protocol, host, port, path, waitForDns }, connectTimeout)
+      tryConnect({ protocol, host, port, path, waitForDns, ipVersion }, connectTimeout)
         .then((open) => {
           debug(`Socket status is: ${open}`);
 
           //  The socket is open, we're done.
           if (open) {
             outputFunction.connected();
-            return resolve(true);
+            return resolve({ open: true, ipVersion });
           }
 
           //  If we have a timeout, and we've passed it, we're done.
           if (timeout && (new Date() - startTime) > timeout) {
             outputFunction.timeout();
-            return resolve(false);
+            return resolve({ open: false });
+          }
+
+          // Check for IPv6 next
+          if (ipVersion === 4 && !net.isIP(host)) {
+            return loop(6);
           }
 
           //  Run the loop again.

--- a/lib/wait-port.spec.js
+++ b/lib/wait-port.spec.js
@@ -13,9 +13,10 @@ describe('wait-port', () => {
     //  Start waiting for port 9021 to open. If it opens we pass, otherwise we
     //  fail.
     return waitPort({ host: '127.0.0.1', port: 9021, output: 'silent' })
-      .then((open) => {
+      .then(({ open, ipVersion }) => {
         server.close();
         assert(open === true, 'Waiting for the port should find it to open.');
+        assert(ipVersion === 4, 'Waiting for the port should find it on IPv4.');
       });
   });
 
@@ -26,9 +27,10 @@ describe('wait-port', () => {
     //  Start waiting for port 9021 to open. If it opens we pass, otherwise we
     //  fail.
     return waitPort({ host: '::1', port: 9021, output: 'silent' })
-      .then((open) => {
+      .then(({ open, ipVersion }) => {
         server.close();
         assert(open === true, 'Waiting for the port should find it to open.');
+        assert(ipVersion === 4, 'Waiting for the port should find it on IPv4.');
       });
   });
 
@@ -39,22 +41,26 @@ describe('wait-port', () => {
     //  Start waiting for port 9021 to open. If it opens we pass, otherwise we
     //  fail.
     return waitPort({ host: 'localhost', port: 9021, output: 'silent' })
-      .then((open) => {
+      .then(({ open, ipVersion }) => {
         server.close();
         assert(open === true, 'Waiting for the port should find it to open.');
+        assert(ipVersion === 4, 'Waiting for the port should find it on IPv4.');
       });
   });
 
   it('should wait until a port is open IPv6 with localhost', () => {
     const server = net.createServer();
-    server.listen(9021, '::1');
+    setTimeout( ()=> {
+      server.listen(9021, '::1');
+    }, 1000);
 
     //  Start waiting for port 9021 to open. If it opens we pass, otherwise we
     //  fail.
     return waitPort({ host: 'localhost', port: 9021, output: 'silent' })
-      .then((open) => {
+      .then(({ open, ipVersion }) => {
         server.close();
         assert(open === true, 'Waiting for the port should find it to open.');
+        assert(ipVersion === 6, 'Waiting for the port should find it on IPv4.');
       });
   });
 
@@ -65,7 +71,7 @@ describe('wait-port', () => {
     //  Start waiting for port 9021 to open.
     const start = new Date();
     return waitPort({ host: '127.0.0.1', port: 9021, timeout, output: 'silent' })
-      .then((open) => {
+      .then(({ open }) => {
         assert(open === false, 'The port should not be open.');
 
         //  Make sure we are close to the timeout.
@@ -77,7 +83,7 @@ describe('wait-port', () => {
 
   it('should timeout after the specified time even with a non-routable address', () => {
     return waitPort({ host: '10.255.255.1', port: 9021, timeout: 500, output: 'silent' })
-      .then((open) => {
+      .then(({ open }) => {
         assert(open === false, 'The port should not be open.');
       });
   });
@@ -88,7 +94,7 @@ describe('wait-port', () => {
     server.listen(9021, '127.0.0.1');
 
     return waitPort({ protocol: 'http', host: '127.0.0.1', port: 9021, timeout: 500, output: 'silent' })
-      .then((open) => {
+      .then(({ open }) => {
         server.close();
         assert(open === false, 'The port should not be open for http.');
       });
@@ -102,7 +108,7 @@ describe('wait-port', () => {
     }).listen(9022);
 
     return waitPort({ protocol: 'http', host: '127.0.0.1', port: 9022, timeout: 3000, output: 'silent' })
-      .then((open) => {
+      .then(({ open }) => {
         server.close();
         assert(open === false, 'The success condition should not be met');
       });
@@ -129,7 +135,7 @@ describe('wait-port', () => {
     //  Start waiting for port 9021 to open.
     const start = new Date();
     return waitPort({ host: 'ireallyhopethatthisdomainnamedoesnotexist.com', waitForDns: true, port: 9021, timeout, output: 'silent' })
-      .then((open) => {
+      .then(({ open }) => {
         assert(open === false, 'The port should not be open.');
 
         //  Make sure we are close to the timeout.
@@ -148,9 +154,10 @@ describe('wait-port', () => {
     }).listen(9023);
 
     return waitPort({ protocol: 'http', host: '127.0.0.1', port: 9023, timeout: 3000, output: 'silent' })
-      .then((open) => {
+      .then(({ open, ipVersion }) => {
         server.close();
         assert(open === true, 'The success condition should be met');
+        assert(ipVersion === 4, 'It should be open on IPv4');
       });
   });
 });

--- a/lib/wait-port.spec.js
+++ b/lib/wait-port.spec.js
@@ -5,7 +5,7 @@ const waitPort = require('./wait-port');
 
 describe('wait-port', () => {
 
-  it('should wait until a port is open', () => {
+  it('should wait until a port is open IPv4', () => {
 
     const server = net.createServer();
     server.listen(9021, '127.0.0.1');
@@ -13,6 +13,45 @@ describe('wait-port', () => {
     //  Start waiting for port 9021 to open. If it opens we pass, otherwise we
     //  fail.
     return waitPort({ host: '127.0.0.1', port: 9021, output: 'silent' })
+      .then((open) => {
+        server.close();
+        assert(open === true, 'Waiting for the port should find it to open.');
+      });
+  });
+
+  it('should wait until a port is open IPv6', () => {
+    const server = net.createServer();
+    server.listen(9021, '::1');
+
+    //  Start waiting for port 9021 to open. If it opens we pass, otherwise we
+    //  fail.
+    return waitPort({ host: '::1', port: 9021, output: 'silent' })
+      .then((open) => {
+        server.close();
+        assert(open === true, 'Waiting for the port should find it to open.');
+      });
+  });
+
+  it('should wait until a port is open IPv4 with localhost', () => {
+    const server = net.createServer();
+    server.listen(9021, '127.0.0.1');
+
+    //  Start waiting for port 9021 to open. If it opens we pass, otherwise we
+    //  fail.
+    return waitPort({ host: 'localhost', port: 9021, output: 'silent' })
+      .then((open) => {
+        server.close();
+        assert(open === true, 'Waiting for the port should find it to open.');
+      });
+  });
+
+  it('should wait until a port is open IPv6 with localhost', () => {
+    const server = net.createServer();
+    server.listen(9021, '::1');
+
+    //  Start waiting for port 9021 to open. If it opens we pass, otherwise we
+    //  fail.
+    return waitPort({ host: 'localhost', port: 9021, output: 'silent' })
       .then((open) => {
         server.close();
         assert(open === true, 'Waiting for the port should find it to open.');
@@ -28,14 +67,14 @@ describe('wait-port', () => {
     return waitPort({ host: '127.0.0.1', port: 9021, timeout, output: 'silent' })
       .then((open) => {
         assert(open === false, 'The port should not be open.');
-        
+
         //  Make sure we are close to the timeout.
         const elapsed = new Date() - start;
         assert(((timeout - delta) < elapsed) && (elapsed < (timeout + delta)),
           `Timeout took ${elapsed}ms, should be close to ${timeout}ms.`);
       });
   });
-  
+
   it('should timeout after the specified time even with a non-routable address', () => {
     return waitPort({ host: '10.255.255.1', port: 9021, timeout: 500, output: 'silent' })
       .then((open) => {
@@ -92,15 +131,15 @@ describe('wait-port', () => {
     return waitPort({ host: 'ireallyhopethatthisdomainnamedoesnotexist.com', waitForDns: true, port: 9021, timeout, output: 'silent' })
       .then((open) => {
         assert(open === false, 'The port should not be open.');
-        
+
         //  Make sure we are close to the timeout.
         const elapsed = new Date() - start;
         assert(((timeout - delta) < elapsed) && (elapsed < (timeout + delta)),
           `Timeout took ${elapsed}ms, should be close to ${timeout}ms.`);
       });
   });
-  
-  
+
+
   it('should successfully wait for a valid http response', () => {
     const server = http.createServer((req, res) => {
       res.writeHead(200);


### PR DESCRIPTION
This change resolves issues with Node.js 17 and newer and fixes #81.

Node.js 17 and newer do not order ip addresses when resolving them, this means that a server that is listening on `localhost` previously always listened on `127.0.0.1` with the Node.js 17+ it might also be listening on `::1`. To support this new behavior, wait-port now tries to connect to IPv4 first and then to IPv6 when the supplied hostname is not an IP.

I change the return value to include the ipVersion and because of this this is a breaking change.

BREAKING CHANGE: Returns now an object instead of an boolean. The object
contains the property `open: boolean` and if `open` is `true` it will
also contain `ipVersion` which will be `4` or `6` dependening on which IP
version the open port was found on.