### PR TITLE
fix: Handle EADDRNOTAVAIL if IPv6 not enabled

### DIFF
--- a/lib/wait-port.js
+++ b/lib/wait-port.js
@@ -4,6 +4,8 @@ const outputFunctions = require('./output-functions');
 const validateParameters = require('./validate-parameters');
 const ConnectionError = require('./errors/connection-error');
 
+let IPv6enabled = true;
+
 function createConnectionWithTimeout({ host, port, ipVersion }, timeout, callback) {
   //  Variable to hold the timer we'll use to kill the socket if we don't
   //  connect in time.
@@ -114,6 +116,15 @@ function tryConnect(options, timeout) {
             // ...otherwise, we will explicitly fail with a meaningful error for
             //  the user.
             return reject(new ConnectionError(`The address '${options.host}' cannot be found`));
+          } else if (err.code === 'EADDRNOTAVAIL' && options.ipVersion === 6) {
+            //  This will occur if the IP address we are trying to connect to does not exist
+            //  This can happen for ::1 or other IPv6 addresses if the IPv6 stack is not enabled.
+            //  In this case we disable the IPv6 lookup
+            debug('Socket cannot be opened for IPv6: EADDRNOTAVAIL');
+            debug('Disabling IPv6 lookup');
+            IPv6enabled = false;
+
+            return resolve(false);
           }
 
           //  Trying to open the socket has resulted in an error we don't
@@ -208,7 +219,7 @@ function waitPort(params) {
           }
 
           // Check for IPv6 next
-          if (ipVersion === 4 && !net.isIP(host)) {
+          if (IPv6enabled && ipVersion === 4 && !net.isIP(host)) {
             return loop(6);
           }
 


### PR DESCRIPTION
The logic will now disable IPv6 lookups when `EADDRNOTAVAIL` happens after it resolved a hostname to IPv6. 
If someone provides an IPv6 address as host themselves we would fail as before.

This happens if wait-port is used on for example circle-ci, which does not have IPv6 support in its containers.

Writting a test for this scenario is really hard, and I wouldn't know how.

I did validate this works on circle-ci:
```
...
◈ Starting Netlify Dev with #custom
- Waiting for framework port 8080. This can be configured using the 'targetPort' property in the netlify.toml
  wait-port Socket error: Error: connect ECONNREFUSED 127.0.0.1:8080 +0ms
  wait-port Socket not open: ECONNREFUSED +0ms
  wait-port Socket status is: false +0ms
  wait-port Socket error: Error: connect EADDRNOTAVAIL ::1:8080 - Local (:::0) +2ms
  wait-port Socket cannot be opened for IPv6: Error: connect EADDRNOTAVAIL ::1:8080 - Local (:::0) +0ms
  wait-port Disabling IPv6 lookup +0ms
  wait-port Socket status is: false +1ms
$ cross-env REACT_APP_QUIET=true yarn webpack-dev-loud
$ webpack serve --config webpack.dev.js
  wait-port Socket error: Error: connect ECONNREFUSED 127.0.0.1:8080 +1s
  wait-port Socket not open: ECONNREFUSED +0ms
  wait-port Socket status is: false +0ms
  wait-port Socket error: Error: connect ECONNREFUSED 127.0.0.1:8080 +1s
  wait-port Socket not open: ECONNREFUSED +0ms
  wait-port Socket status is: false +0ms
...
```