### PR TITLE
fix: Handle systems without IPv6 properly

### DIFF
--- a/lib/wait-port.js
+++ b/lib/wait-port.js
@@ -103,6 +103,15 @@ function tryConnect(options, timeout) {
             debug('Socket not open: ECONNRESET');
             socket.destroy();
             return resolve(false);
+          } else if (options.ipVersion === 6 && (err.code === 'EADDRNOTAVAIL' || err.code === 'ENOTFOUND')) {
+            //  This will occur if the IP address we are trying to connect to does not exist
+            //  This can happen for ::1 or other IPv6 addresses if the IPv6 stack is not enabled.
+            //  In this case we disable the IPv6 lookup
+            debug(`Socket cannot be opened for IPv6: ${err.code}`);
+            debug('Disabling IPv6 lookup');
+            IPv6enabled = false;
+            socket.destroy();
+            return resolve(false);
           } else if (err.code === 'ENOTFOUND') {
             //  This will occur if the address is not found, i.e. due to a dns
             //  lookup fail (normally a problem if the domain is wrong).
@@ -116,21 +125,19 @@ function tryConnect(options, timeout) {
             // ...otherwise, we will explicitly fail with a meaningful error for
             //  the user.
             return reject(new ConnectionError(`The address '${options.host}' cannot be found`));
-          } else if (err.code === 'EADDRNOTAVAIL' && options.ipVersion === 6) {
-            //  This will occur if the IP address we are trying to connect to does not exist
-            //  This can happen for ::1 or other IPv6 addresses if the IPv6 stack is not enabled.
-            //  In this case we disable the IPv6 lookup
-            debug('Socket cannot be opened for IPv6: EADDRNOTAVAIL');
-            debug('Disabling IPv6 lookup');
-            IPv6enabled = false;
-
-            return resolve(false);
           }
 
           //  Trying to open the socket has resulted in an error we don't
           //  understand. Better give up.
           debug(`Unexpected error trying to open socket: ${err}`);
           socket.destroy();
+
+          // If we are currently checking for IPv6 we ignore this error and disable IPv6
+          if (options.ipVersion === 6) {
+            IPv6enabled = false;
+            return resolve(false);
+          }
+
           return reject(err);
         }
 


### PR DESCRIPTION
This fixes IPv6 again. 
On systems that have the IPv6 stack disabled (for example ubuntu) the name resolution won't even work for IPv6 and `ENOTFOUND` throws.

This PR adds  code that handles this case and also disables IPv6.

https://github.com/netlify/cli/issues/5166

I also added some generic error handling for IPv6 on unexpected errors. So if an unexpected error happens while we are using IPv6 we simply ignore the error and disable IPv6.

I tried to come up with some tests but this is really hard to test. I have an idea though, by disabling IPv6 in the github actions image, but I will do that separatly.