### PR TITLE
feat: add autoSelectFamily for happy eyeballs support

### DIFF
--- a/lib/wait-port.js
+++ b/lib/wait-port.js
@@ -12,7 +12,7 @@ function createConnectionWithTimeout({ host, port, ipVersion }, timeout, callbac
   let timer = null;
 
   //  Try and open the socket, with the params and callback.
-  const socket = net.createConnection({ host, port, family: ipVersion }, (err) => {
+  const socket = net.createConnection({ host, port, family: ipVersion, autoSelectFamily: true }, (err) => {
     if (!err) clearTimeout(timer);
     return callback(err);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5056,8 +5056,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "agent-base": {
       "version": "6.0.2",


### PR DESCRIPTION
In some environments, waiting on localhost can cause it to pick either ipv6 or ipv4 which can cause issue with certain sets of software (namely Docker network bridges which are exposed on ipv4 only). That being said, Node add Happy Eyeball support in https://github.com/nodejs/node/pull/44731, which was released in Node 18, the currently support LTS. This PR adds the `autoSelectFamily` option to support said environments. Let me know if you have any questions. Thanks!

`npx wait-port 1132`