### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ waitPort(params)
     else console.log('The port did not open before the timeout...');
   })
   .catch((err) => {
-    console.err(`An unknown error occured while waiting for the port: ${err}`);
+    console.error(`An unknown error occured while waiting for the port: ${err}`);
   });
 ```
 


### PR DESCRIPTION
`console.err()` is not a function; it should be `console.error()` 😊

https://nodejs.org/docs/latest/api/console.html#consoleerrordata-args