### PR TITLE
Remove `waitPort` call from `wait-port.js`

### DIFF
--- a/lib/wait-port.js
+++ b/lib/wait-port.js
@@ -245,6 +245,3 @@ function waitPort(params) {
 }
 
 module.exports = waitPort;
-waitPort({
-  port: 3000
-})


### PR DESCRIPTION
An exported utility shouldn't come with a side-effect like this.